### PR TITLE
Add console log when server is listening on a port

### DIFF
--- a/src/bin/www
+++ b/src/bin/www
@@ -86,5 +86,6 @@ const server = http.createServer(app)
  */
 
 server.listen(port)
+console.log(`listening on 0.0.0.0:${ port }`)
 server.on('error', onError)
 server.on('listening', onListening)


### PR DESCRIPTION
#31 

I added a message to the console when the server starts so we know which port it's listening on